### PR TITLE
use write_jar_script

### DIFF
--- a/rdflint.rb
+++ b/rdflint.rb
@@ -9,15 +9,11 @@ class Rdflint < Formula
   depends_on "openjdk"
 
   def install
-    system "echo '#!/bin/sh' > rdflint"
-    system "echo 'JAVA_HOME=$(/usr/libexec/java_home)' >> rdflint"
-    system "echo '$JAVA_HOME/bin/java' -jar #{libexec}/rdflint-#{RDFLINT_VERSION}.jar '$@' >> rdflint"
-    system "chmod 555 rdflint"
     libexec.install "rdflint-#{RDFLINT_VERSION}.jar"
-    bin.install 'rdflint'
+    bin.write_jar_script libexec/"rdflint-#{RDFLINT_VERSION}.jar", "rdflint"
   end
 
   test do
-    system "#{bin}/rdflint"
+    system bin/"rdflint"
   end
 end


### PR DESCRIPTION
現在の rdflint.jar を実行するシェルスクリプトは `$@` がダブルクォートで囲まれておらず、空白を含む引数が渡された場合うまく動きません。

Homebrew Formula の Pathname クラスには `write_jar_script` という便利メソッドが生えているので、それを利用すると良いかと思います。

cf.
- [Class: Pathname — Homebrew Ruby API](https://rubydoc.brew.sh/Pathname#write_jar_script-instance_method) (Pathname#write_jar_script)
- [jarで作成したCLIツールをhomebrewで配布するまで](https://zenn.dev/kesin11/scraps/954ecc429c5096)